### PR TITLE
Skip mass assignment security for cache updates

### DIFF
--- a/lib/acts_as_votable/votable.rb
+++ b/lib/acts_as_votable/votable.rb
@@ -144,7 +144,7 @@ module ActsAsVotable
         updates[:cached_votes_down] = count_votes_down(true)
       end
 
-      self.update_attributes(updates) if updates.size > 0
+      self.update_attributes(updates, :without_protection => true) if updates.size > 0
 
     end
 


### PR DESCRIPTION
Cached columns should not be included in accessible attributes.
