### PR TITLE
Rails 4 migration includes duplicate index creation

### DIFF
--- a/lib/generators/acts_as_votable/migration/templates/active_record/migration.rb
+++ b/lib/generators/acts_as_votable/migration/templates/active_record/migration.rb
@@ -11,8 +11,11 @@ class ActsAsVotableMigration < ActiveRecord::Migration
       t.timestamps
     end
 
-    add_index :votes, [:votable_id, :votable_type]
-    add_index :votes, [:voter_id, :voter_type]
+    if ActiveRecord::VERSION::MAJOR < 4
+      add_index :votes, [:votable_id, :votable_type]
+      add_index :votes, [:voter_id, :voter_type]
+    end
+
     add_index :votes, [:voter_id, :voter_type, :vote_scope]
     add_index :votes, [:votable_id, :votable_type, :vote_scope]
   end


### PR DESCRIPTION
Rails 4 adds an index automatically for a references attribute, so only add the explicit index creation statements when the ActiveRecord version is less than 4.
