### PR TITLE
Fix mistype in 'def scope_cache_field' (ActsAsVotable::Votable)

### DIFF
--- a/lib/acts_as_votable/votable.rb
+++ b/lib/acts_as_votable/votable.rb
@@ -154,7 +154,7 @@ module ActsAsVotable
         "cached_scoped_#{vote_scope}_votes_score="
       when :cached_votes_score
         "cached_scoped_#{vote_scope}_votes_score"
-      when :cached_weighted_scope
+      when :cached_weighted_score
         "cached_weighted_#{vote_scope}_score"
       when :cached_weighted_score=
         "cached_weighted_#{vote_scope}_score="


### PR DESCRIPTION
Need to change 'when :cached_weighted_scope' -> 'when :cached_weighted_score' since 'score' is called in 'def update_cached_votes'.
