### PR TITLE
Add scope feature for Voter method 'unvote_for'

### DIFF
--- a/lib/acts_as_votable/voter.rb
+++ b/lib/acts_as_votable/voter.rb
@@ -47,8 +47,8 @@ module ActsAsVotable
       vote :votable => model, :vote_scope => args[:vote_scope], :vote => false
     end
 
-    def unvote_for model
-      model.unvote :voter => self
+    def unvote_for model, args={}
+      model.unvote :voter => self, :vote_scope => args[:vote_scope]
     end
 
     # results


### PR DESCRIPTION
Update Voter method 'unvote_for':
- add optional parameters 'args={}'
- pass to method votable.unvote additional parameter ':vote_scope => args[:vote_scope]'

This change allows use similar form for voting and unvoting by voter with scope. Otherwise unvoting with scope can by done by votable only.
