### PR TITLE
Allow updating vote weight

### DIFF
--- a/lib/acts_as_votable/votable.rb
+++ b/lib/acts_as_votable/votable.rb
@@ -89,8 +89,6 @@ module ActsAsVotable
           :voter => options[:voter],
           :vote_scope => options[:vote_scope]
         )
-        #Allowing for a vote_weight to be associated with every vote. Could change with every voter object
-        vote.vote_weight = (options[:vote_weight].to_i if options[:vote_weight].present?) || 1
       else
         # this voter is potentially changing his vote
         vote = _votes_.last
@@ -99,6 +97,9 @@ module ActsAsVotable
       last_update = vote.updated_at
 
       vote.vote_flag = votable_words.meaning_of(options[:vote])
+
+      #Allowing for a vote_weight to be associated with every vote. Could change with every voter object
+      vote.vote_weight = (options[:vote_weight].to_i if options[:vote_weight].present?) || 1
 
       if vote.save
         self.vote_registered = true if last_update != vote.updated_at

--- a/spec/shared_example/votable_model_spec.rb
+++ b/spec/shared_example/votable_model_spec.rb
@@ -81,9 +81,15 @@ shared_examples "a votable_model" do
     votable.vote_registered?.should be false
   end
 
-  it "should count the vote as registered if the voter has voted and the vote has changed" do
+  it "should count the vote as registered if the voter has voted and the vote flag has changed" do
     votable.vote_by :voter => voter, :vote => true
     votable.vote_by :voter => voter, :vote => 'dislike'
+    votable.vote_registered?.should be true
+  end
+
+  it "should count the vote as registered if the voter has voted and the vote weight has changed" do
+    votable.vote_by :voter => voter, :vote => true, :vote_weight => 1
+    votable.vote_by :voter => voter, :vote => true, :vote_weight => 2
     votable.vote_registered?.should be true
   end
 


### PR DESCRIPTION
Currently I'm using `acts_as_votable` as a kind of "`acts_as_ratable`" for one of my models, i.e. all votes are upvotes ranging from 1 to 5 (a.k.a. 5-star ratings).

Currently when a user tries to change her vote (i.e. weight) the vote doesn't register as weight assignment only takes place for a new vote. This pull request simply allows `acts_as_votable` to be seamlessly used as a rating system.
