### PR TITLE
voter_type and votable_type are always base_class

### DIFF
--- a/lib/acts_as_votable/votable.rb
+++ b/lib/acts_as_votable/votable.rb
@@ -79,7 +79,7 @@ module ActsAsVotable
       _votes_ = find_votes_for({
         :voter_id => options[:voter].id,
         :vote_scope => options[:vote_scope],
-        :voter_type => options[:voter].class.name
+        :voter_type => options[:voter].class.base_class.name
       })
 
       if _votes_.count == 0 or options[:duplicate]
@@ -114,7 +114,7 @@ module ActsAsVotable
 
     def unvote args = {}
       return false if args[:voter].nil?
-      _votes_ = find_votes_for(:voter_id => args[:voter].id, :vote_scope => args[:vote_scope], :voter_type => args[:voter].class.name)
+      _votes_ = find_votes_for(:voter_id => args[:voter].id, :vote_scope => args[:vote_scope], :voter_type => args[:voter].class.base_class.name)
 
       return true if _votes_.size == 0
       _votes_.each(&:destroy)
@@ -271,7 +271,7 @@ module ActsAsVotable
 
     # voters
     def voted_on_by? voter
-      votes = find_votes_for :voter_id => voter.id, :voter_type => voter.class.name
+      votes = find_votes_for :voter_id => voter.id, :voter_type => voter.class.base_class.name
       votes.count > 0
     end
 

--- a/lib/acts_as_votable/voter.rb
+++ b/lib/acts_as_votable/voter.rb
@@ -53,25 +53,25 @@ module ActsAsVotable
 
     # results
     def voted_on? votable, args={}
-      votes = find_votes(:votable_id => votable.id, :votable_type => votable.class.name,
+      votes = find_votes(:votable_id => votable.id, :votable_type => votable.class.base_class.name,
                          :vote_scope => args[:vote_scope])
       votes.size > 0
     end
 
     def voted_up_on? votable, args={}
-      votes = find_votes(:votable_id => votable.id, :votable_type => votable.class.name,
+      votes = find_votes(:votable_id => votable.id, :votable_type => votable.class.base_class.name,
                          :vote_scope => args[:vote_scope], :vote_flag => true)
       votes.size > 0
     end
 
     def voted_down_on? votable, args={}
-      votes = find_votes(:votable_id => votable.id, :votable_type => votable.class.name,
+      votes = find_votes(:votable_id => votable.id, :votable_type => votable.class.base_class.name,
                          :vote_scope => args[:vote_scope], :vote_flag => false)
       votes.size > 0
     end
 
     def voted_as_when_voting_on votable, args={}
-      vote = find_votes(:votable_id => votable.id, :votable_type => votable.class.name,
+      vote = find_votes(:votable_id => votable.id, :votable_type => votable.class.base_class.name,
                          :vote_scope => args[:vote_scope]).select(:vote_flag).last
       return nil unless vote
       return vote.vote_flag
@@ -107,7 +107,7 @@ module ActsAsVotable
     end
 
     def find_voted_items extra_conditions = {}
-      options = extra_conditions.merge :voter_id => id, :voter_type => self.class.name
+      options = extra_conditions.merge :voter_id => id, :voter_type => self.class.base_class.name
       include_objects.where(options).collect(&:votable)
     end
 


### PR DESCRIPTION
If one voted for STI'ed model and then called `liked?` on it, it was always `false`, because Vote was implicitly saved with `base_class` in `_type` fields here https://github.com/ryanto/acts_as_votable/blob/master/lib/acts_as_votable/votable.rb#L87, but queried with the subclass condition.
