### PR TITLE
Convert specs to RSpec 2.14.8 syntax with Transpec

### DIFF
--- a/spec/shared_example/votable_model_spec.rb
+++ b/spec/shared_example/votable_model_spec.rb
@@ -1,132 +1,132 @@
 shared_examples "a votable_model" do
   it "should return false when a vote with no voter is saved" do
-    votable.vote_by.should be false
+    expect(votable.vote_by).to be false
   end
 
   it "should have one vote when saved" do
     votable.vote_by :voter => voter, :vote => 'yes'
-    votable.votes_for.size.should == 1
+    expect(votable.votes_for.size).to eq(1)
   end
 
   it "should have one vote when voted on twice by the same person" do
     votable.vote_by :voter => voter, :vote => 'yes'
     votable.vote_by :voter => voter, :vote => 'no'
-    votable.votes_for.size.should == 1
+    expect(votable.votes_for.size).to eq(1)
   end
 
   it "should have two votes_for when voted on twice by the same person with duplicate paramenter" do
     votable.vote_by :voter => voter, :vote => 'yes'
     votable.vote_by :voter => voter, :vote => 'no', :duplicate => true
-    votable.votes_for.size.should == 2
+    expect(votable.votes_for.size).to eq(2)
   end
 
   it "should have one scoped vote when voting under an scope" do
     votable.vote_by :voter => voter, :vote => 'yes', :vote_scope => 'rank'
-    votable.find_votes_for(:vote_scope => 'rank').size.should == 1
+    expect(votable.find_votes_for(:vote_scope => 'rank').size).to eq(1)
   end
 
   it "should have one vote when voted on twice using scope by the same person" do
     votable.vote_by :voter => voter, :vote => 'yes', :vote_scope => 'rank'
     votable.vote_by :voter => voter, :vote => 'no', :vote_scope => 'rank'
-    votable.find_votes_for(:vote_scope => 'rank').size.should == 1
+    expect(votable.find_votes_for(:vote_scope => 'rank').size).to eq(1)
   end
 
   it "should have two votes_for when voting on two different scopes by the same person" do
     votable.vote_by :voter => voter, :vote => 'yes', :vote_scope => 'weekly_rank'
     votable.vote_by :voter => voter, :vote => 'no', :vote_scope => 'monthly_rank'
-    votable.votes_for.size.should == 2
+    expect(votable.votes_for.size).to eq(2)
   end
 
   it "should be callable with vote_up" do
     votable.vote_up voter
-    votable.get_up_votes.first.voter.should == voter
+    expect(votable.get_up_votes.first.voter).to eq(voter)
   end
 
   it "should be callable with vote_down" do
     votable.vote_down voter
-    votable.get_down_votes.first.voter.should == voter
+    expect(votable.get_down_votes.first.voter).to eq(voter)
   end
 
   it "should have 2 votes_for when voted on once by two different people" do
     votable.vote_by :voter => voter
     votable.vote_by :voter => voter2
-    votable.votes_for.size.should == 2
+    expect(votable.votes_for.size).to eq(2)
   end
 
   it "should have one true vote" do
     votable.vote_by :voter => voter
     votable.vote_by :voter => voter2, :vote => 'dislike'
-    votable.get_up_votes.size.should == 1
+    expect(votable.get_up_votes.size).to eq(1)
   end
 
   it "should have 2 false votes_for" do
     votable.vote_by :voter => voter, :vote => 'no'
     votable.vote_by :voter => voter2, :vote => 'dislike'
-    votable.get_down_votes.size.should == 2
+    expect(votable.get_down_votes.size).to eq(2)
   end
 
   it "should have been voted on by voter2" do
     votable.vote_by :voter => voter2, :vote => true
-    votable.find_votes_for.first.voter.id.should be voter2.id
+    expect(votable.find_votes_for.first.voter.id).to be voter2.id
   end
 
   it "should count the vote as registered if this is the voters first vote" do
     votable.vote_by :voter => voter
-    votable.vote_registered?.should be true
+    expect(votable.vote_registered?).to be true
   end
 
   it "should not count the vote as being registered if that voter has already voted and the vote has not changed" do
     votable.vote_by :voter => voter, :vote => true
     votable.vote_by :voter => voter, :vote => 'yes'
-    votable.vote_registered?.should be false
+    expect(votable.vote_registered?).to be false
   end
 
   it "should count the vote as registered if the voter has voted and the vote flag has changed" do
     votable.vote_by :voter => voter, :vote => true
     votable.vote_by :voter => voter, :vote => 'dislike'
-    votable.vote_registered?.should be true
+    expect(votable.vote_registered?).to be true
   end
 
   it "should count the vote as registered if the voter has voted and the vote weight has changed" do
     votable.vote_by :voter => voter, :vote => true, :vote_weight => 1
     votable.vote_by :voter => voter, :vote => true, :vote_weight => 2
-    votable.vote_registered?.should be true
+    expect(votable.vote_registered?).to be true
   end
 
   it "should be voted on by voter" do
     votable.vote_by :voter => voter
-    votable.voted_on_by?(voter).should be true
+    expect(votable.voted_on_by?(voter)).to be true
   end
 
   it "should be able to unvote a voter" do
     votable.liked_by(voter)
     votable.unliked_by(voter)
-    votable.voted_on_by?(voter).should be false
+    expect(votable.voted_on_by?(voter)).to be false
   end
 
   it "should unvote a positive vote" do
     votable.vote_by :voter => voter
     votable.unvote :voter => voter
-    votable.find_votes_for.count.should == 0
+    expect(votable.find_votes_for.count).to eq(0)
   end
 
   it "should set the votable to unregistered after unvoting" do
     votable.vote_by :voter => voter
     votable.unvote :voter => voter
-    votable.vote_registered?.should be false
+    expect(votable.vote_registered?).to be false
   end
 
   it "should unvote a negative vote" do
     votable.vote_by :voter => voter, :vote => 'no'
     votable.unvote :voter => voter
-    votable.find_votes_for.count.should == 0
+    expect(votable.find_votes_for.count).to eq(0)
   end
 
   it "should unvote only the from a single voter" do
     votable.vote_by :voter => voter
     votable.vote_by :voter => voter2
     votable.unvote :voter => voter
-    votable.find_votes_for.count.should == 1
+    expect(votable.find_votes_for.count).to eq(1)
   end
 
   it "should be contained to instances" do
@@ -137,13 +137,13 @@ shared_examples "a votable_model" do
     votable2.vote_by :voter => voter, :vote => true
     votable2.vote_by :voter => voter, :vote => true
 
-    votable.vote_registered?.should be true
-    votable2.vote_registered?.should be false
+    expect(votable.vote_registered?).to be true
+    expect(votable2.vote_registered?).to be false
   end
 
   it "should set default vote weight to 1 if not specified" do
     votable.upvote_by voter
-    votable.find_votes_for.first.vote_weight.should == 1
+    expect(votable.find_votes_for.first.vote_weight).to eq(1)
   end
 
   describe "with cached votes_for" do
@@ -167,144 +167,144 @@ shared_examples "a votable_model" do
     it "should update cached total votes_for if there is a total column" do
       votable_cache.cached_votes_total = 50
       votable_cache.vote_by :voter => voter
-      votable_cache.cached_votes_total.should == 1
+      expect(votable_cache.cached_votes_total).to eq(1)
     end
 
     it "should update cached total votes_for when a vote up is removed" do
       votable_cache.vote_by :voter => voter, :vote => 'true'
       votable_cache.unvote :voter => voter
-      votable_cache.cached_votes_total.should == 0
+      expect(votable_cache.cached_votes_total).to eq(0)
     end
 
     it "should update cached total votes_for when a vote down is removed" do
       votable_cache.vote_by :voter => voter, :vote => 'false'
       votable_cache.unvote :voter => voter
-      votable_cache.cached_votes_total.should == 0
+      expect(votable_cache.cached_votes_total).to eq(0)
     end
 
     it "should update cached score votes_for if there is a score column" do
       votable_cache.cached_votes_score = 50
       votable_cache.vote_by :voter => voter
-      votable_cache.cached_votes_score.should == 1
+      expect(votable_cache.cached_votes_score).to eq(1)
       votable_cache.vote_by :voter => voter2, :vote => 'false'
-      votable_cache.cached_votes_score.should == 0
+      expect(votable_cache.cached_votes_score).to eq(0)
       votable_cache.vote_by :voter => voter, :vote => 'false'
-      votable_cache.cached_votes_score.should == -2
+      expect(votable_cache.cached_votes_score).to eq(-2)
     end
 
     it "should update cached score votes_for when a vote up is removed" do
       votable_cache.vote_by :voter => voter, :vote => 'true'
-      votable_cache.cached_votes_score.should == 1
+      expect(votable_cache.cached_votes_score).to eq(1)
       votable_cache.unvote :voter => voter
-      votable_cache.cached_votes_score.should == 0
+      expect(votable_cache.cached_votes_score).to eq(0)
     end
 
     it "should update cached score votes_for when a vote down is removed" do
       votable_cache.vote_by :voter => voter, :vote => 'false'
-      votable_cache.cached_votes_score.should == -1
+      expect(votable_cache.cached_votes_score).to eq(-1)
       votable_cache.unvote :voter => voter
-      votable_cache.cached_votes_score.should == 0
+      expect(votable_cache.cached_votes_score).to eq(0)
     end
 
     it "should update cached weighted total if there is a weighted total column" do
       votable_cache.cached_weighted_total = 50
       votable_cache.vote_by :voter => voter
-      votable_cache.cached_weighted_total.should == 1
+      expect(votable_cache.cached_weighted_total).to eq(1)
       votable_cache.vote_by :voter => voter2, :vote => 'false'
-      votable_cache.cached_weighted_total.should == 2
+      expect(votable_cache.cached_weighted_total).to eq(2)
     end
 
     it "should update cached weighted total votes_for when a vote up is removed" do
       votable_cache.vote_by :voter => voter, :vote => 'true', :vote_weight => 3
-      votable_cache.cached_weighted_total.should == 3
+      expect(votable_cache.cached_weighted_total).to eq(3)
       votable_cache.unvote :voter => voter
-      votable_cache.cached_weighted_total.should == 0
+      expect(votable_cache.cached_weighted_total).to eq(0)
     end
 
     it "should update cached weighted total votes_for when a vote down is removed" do
       votable_cache.vote_by :voter => voter, :vote => 'false', :vote_weight => 4
-      votable_cache.cached_weighted_total.should == 4
+      expect(votable_cache.cached_weighted_total).to eq(4)
       votable_cache.unvote :voter => voter
-      votable_cache.cached_weighted_total.should == 0
+      expect(votable_cache.cached_weighted_total).to eq(0)
     end
 
     it "should update cached weighted score if there is a weighted score column" do
       votable_cache.cached_weighted_score = 50
       votable_cache.vote_by :voter => voter
-      votable_cache.cached_weighted_score.should == 1
+      expect(votable_cache.cached_weighted_score).to eq(1)
       votable_cache.vote_by :voter => voter2, :vote => 'false'
-      votable_cache.cached_weighted_score.should == 0
+      expect(votable_cache.cached_weighted_score).to eq(0)
       votable_cache.vote_by :voter => voter, :vote => 'false'
-      votable_cache.cached_weighted_score.should == -2
+      expect(votable_cache.cached_weighted_score).to eq(-2)
     end
 
     it "should update cached weighted score votes_for when a vote up is removed" do
       votable_cache.vote_by :voter => voter, :vote => 'true', :vote_weight => 3
-      votable_cache.cached_weighted_score.should == 3
+      expect(votable_cache.cached_weighted_score).to eq(3)
       votable_cache.unvote :voter => voter
-      votable_cache.cached_weighted_score.should == 0
+      expect(votable_cache.cached_weighted_score).to eq(0)
     end
 
     it "should update cached weighted score votes_for when a vote down is removed" do
       votable_cache.vote_by :voter => voter, :vote => 'false', :vote_weight => 4
-      votable_cache.cached_weighted_score.should == -4
+      expect(votable_cache.cached_weighted_score).to eq(-4)
       votable_cache.unvote :voter => voter
-      votable_cache.cached_weighted_score.should == 0
+      expect(votable_cache.cached_weighted_score).to eq(0)
     end
 
     it "should update cached up votes_for if there is an up vote column" do
       votable_cache.cached_votes_up = 50
       votable_cache.vote_by :voter => voter
       votable_cache.vote_by :voter => voter
-      votable_cache.cached_votes_up.should == 1
+      expect(votable_cache.cached_votes_up).to eq(1)
     end
 
     it "should update cached down votes_for if there is a down vote column" do
       votable_cache.cached_votes_down = 50
       votable_cache.vote_by :voter => voter, :vote => 'false'
-      votable_cache.cached_votes_down.should == 1
+      expect(votable_cache.cached_votes_down).to eq(1)
     end
 
     it "should update cached up votes_for when a vote up is removed" do
       votable_cache.vote_by :voter => voter, :vote => 'true'
       votable_cache.unvote :voter => voter
-      votable_cache.cached_votes_up.should == 0
+      expect(votable_cache.cached_votes_up).to eq(0)
     end
 
     it "should update cached down votes_for when a vote down is removed" do
       votable_cache.vote_by :voter => voter, :vote => 'false'
       votable_cache.unvote :voter => voter
-      votable_cache.cached_votes_down.should == 0
+      expect(votable_cache.cached_votes_down).to eq(0)
     end
 
     it "should select from cached total votes_for if there a total column" do
       votable_cache.vote_by :voter => voter
       votable_cache.cached_votes_total = 50
-      votable_cache.count_votes_total.should == 50
+      expect(votable_cache.count_votes_total).to eq(50)
     end
 
     it "should select from cached up votes_for if there is an up vote column" do
       votable_cache.vote_by :voter => voter
       votable_cache.cached_votes_up = 50
-      votable_cache.count_votes_up.should == 50
+      expect(votable_cache.count_votes_up).to eq(50)
     end
 
     it "should select from cached down votes_for if there is a down vote column" do
       votable_cache.vote_by :voter => voter, :vote => 'false'
       votable_cache.cached_votes_down = 50
-      votable_cache.count_votes_down.should == 50
+      expect(votable_cache.count_votes_down).to eq(50)
     end
 
     it "should select from cached weighted total if there is a weighted total column" do
       votable_cache.vote_by :voter => voter, :vote => 'false'
       votable_cache.cached_weighted_total = 50
-      votable_cache.weighted_total.should == 50
+      expect(votable_cache.weighted_total).to eq(50)
     end
 
     it "should select from cached weighted score if there is a weighted score column" do
       votable_cache.vote_by :voter => voter, :vote => 'false'
       votable_cache.cached_weighted_score = 50
-      votable_cache.weighted_score.should == 50
+      expect(votable_cache.weighted_score).to eq(50)
     end
 
   end
@@ -314,86 +314,86 @@ shared_examples "a votable_model" do
     it "should update cached total votes_for if there is a total column" do
       votable_cache.cached_scoped_test_votes_total = 50
       votable_cache.vote_by :voter => voter, :vote_scope => "test"
-      votable_cache.cached_scoped_test_votes_total.should == 1
+      expect(votable_cache.cached_scoped_test_votes_total).to eq(1)
     end
 
     it "should update cached total votes_for when a vote up is removed" do
       votable_cache.vote_by :voter => voter, :vote => 'true', :vote_scope => "test"
       votable_cache.unvote :voter => voter, :vote_scope => "test"
-      votable_cache.cached_scoped_test_votes_total.should == 0
+      expect(votable_cache.cached_scoped_test_votes_total).to eq(0)
     end
 
     it "should update cached total votes_for when a vote down is removed" do
       votable_cache.vote_by :voter => voter, :vote => 'false', :vote_scope => "test"
       votable_cache.unvote :voter => voter, :vote_scope => "test"
-      votable_cache.cached_scoped_test_votes_total.should == 0
+      expect(votable_cache.cached_scoped_test_votes_total).to eq(0)
     end
 
     it "should update cached score votes_for if there is a score column" do
       votable_cache.cached_scoped_test_votes_score = 50
       votable_cache.vote_by :voter => voter, :vote_scope => "test"
-      votable_cache.cached_scoped_test_votes_score.should == 1
+      expect(votable_cache.cached_scoped_test_votes_score).to eq(1)
       votable_cache.vote_by :voter => voter2, :vote => 'false', :vote_scope => "test"
-      votable_cache.cached_scoped_test_votes_score.should == 0
+      expect(votable_cache.cached_scoped_test_votes_score).to eq(0)
       votable_cache.vote_by :voter => voter, :vote => 'false', :vote_scope => "test"
-      votable_cache.cached_scoped_test_votes_score.should == -2
+      expect(votable_cache.cached_scoped_test_votes_score).to eq(-2)
     end
 
     it "should update cached score votes_for when a vote up is removed" do
       votable_cache.vote_by :voter => voter, :vote => 'true', :vote_scope => "test"
-      votable_cache.cached_scoped_test_votes_score.should == 1
+      expect(votable_cache.cached_scoped_test_votes_score).to eq(1)
       votable_cache.unvote :voter => voter, :vote_scope => "test"
-      votable_cache.cached_scoped_test_votes_score.should == 0
+      expect(votable_cache.cached_scoped_test_votes_score).to eq(0)
     end
 
     it "should update cached score votes_for when a vote down is removed" do
       votable_cache.vote_by :voter => voter, :vote => 'false', :vote_scope => "test"
-      votable_cache.cached_scoped_test_votes_score.should == -1
+      expect(votable_cache.cached_scoped_test_votes_score).to eq(-1)
       votable_cache.unvote :voter => voter, :vote_scope => "test"
-      votable_cache.cached_scoped_test_votes_score.should == 0
+      expect(votable_cache.cached_scoped_test_votes_score).to eq(0)
     end
 
     it "should update cached up votes_for if there is an up vote column" do
       votable_cache.cached_scoped_test_votes_up = 50
       votable_cache.vote_by :voter => voter, :vote_scope => "test"
       votable_cache.vote_by :voter => voter, :vote_scope => "test"
-      votable_cache.cached_scoped_test_votes_up.should == 1
+      expect(votable_cache.cached_scoped_test_votes_up).to eq(1)
     end
 
     it "should update cached down votes_for if there is a down vote column" do
       votable_cache.cached_scoped_test_votes_down = 50
       votable_cache.vote_by :voter => voter, :vote => 'false', :vote_scope => "test"
-      votable_cache.cached_scoped_test_votes_down.should == 1
+      expect(votable_cache.cached_scoped_test_votes_down).to eq(1)
     end
 
     it "should update cached up votes_for when a vote up is removed" do
       votable_cache.vote_by :voter => voter, :vote => 'true', :vote_scope => "test"
       votable_cache.unvote :voter => voter, :vote_scope => "test"
-      votable_cache.cached_scoped_test_votes_up.should == 0
+      expect(votable_cache.cached_scoped_test_votes_up).to eq(0)
     end
 
     it "should update cached down votes_for when a vote down is removed" do
       votable_cache.vote_by :voter => voter, :vote => 'false', :vote_scope => "test"
       votable_cache.unvote :voter => voter, :vote_scope => "test"
-      votable_cache.cached_scoped_test_votes_down.should == 0
+      expect(votable_cache.cached_scoped_test_votes_down).to eq(0)
     end
 
     it "should select from cached total votes_for if there a total column" do
       votable_cache.vote_by :voter => voter, :vote_scope => "test"
       votable_cache.cached_scoped_test_votes_total = 50
-      votable_cache.count_votes_total(false, "test").should == 50
+      expect(votable_cache.count_votes_total(false, "test")).to eq(50)
     end
 
     it "should select from cached up votes_for if there is an up vote column" do
       votable_cache.vote_by :voter => voter, :vote_scope => "test"
       votable_cache.cached_scoped_test_votes_up = 50
-      votable_cache.count_votes_up(false, "test").should == 50
+      expect(votable_cache.count_votes_up(false, "test")).to eq(50)
     end
 
     it "should select from cached down votes_for if there is a down vote column" do
       votable_cache.vote_by :voter => voter, :vote => 'false', :vote_scope => "test"
       votable_cache.cached_scoped_test_votes_down = 50
-      votable_cache.count_votes_down(false, "test").should == 50
+      expect(votable_cache.count_votes_down(false, "test")).to eq(50)
     end
 
   end
@@ -404,18 +404,18 @@ shared_examples "a votable_model" do
       votable = VotableChildOfStiNotVotable.create(:name => 'sti child')
 
       votable.vote_by :voter => voter, :vote => 'yes'
-      votable.votes_for.size.should == 1
+      expect(votable.votes_for.size).to eq(1)
     end
 
     it "should not be able to vote on a parent non votable" do
-      StiNotVotable.should_not be_votable
+      expect(StiNotVotable).not_to be_votable
     end
 
     it "should be able to vote on a child when its parent is votable" do
       votable = ChildOfStiVotable.create(:name => 'sti child')
 
       votable.vote_by :voter => voter, :vote => 'yes'
-      votable.votes_for.size.should == 1
+      expect(votable.votes_for.size).to eq(1)
     end
   end
 end

--- a/spec/shared_example/voter_model_spec.rb
+++ b/spec/shared_example/voter_model_spec.rb
@@ -3,171 +3,171 @@ shared_examples "a voter_model" do
 
   it "should be voted on after a voter has voted" do
     votable.vote_by :voter => voter
-    voter.voted_on?(votable).should be true
-    voter.voted_for?(votable).should be true
+    expect(voter.voted_on?(votable)).to be true
+    expect(voter.voted_for?(votable)).to be true
   end
 
   it "should not be voted on if a voter has not voted" do
-    voter.voted_on?(votable).should be false
+    expect(voter.voted_on?(votable)).to be false
   end
 
   it "should be voted on after a voter has voted under scope" do
     votable.vote_by :voter => voter, :vote_scope => 'rank'
-    voter.voted_on?(votable, :vote_scope => 'rank').should be true
+    expect(voter.voted_on?(votable, :vote_scope => 'rank')).to be true
   end
 
   it "should not be voted on other scope after a voter has voted under one scope" do
     votable.vote_by :voter => voter, :vote_scope => 'rank'
-    voter.voted_on?(votable).should be false
+    expect(voter.voted_on?(votable)).to be false
   end
 
   it "should be voted as true when a voter has voted true" do
     votable.vote_by :voter => voter
-    voter.voted_as_when_voted_on(votable).should be true
-    voter.voted_as_when_voted_for(votable).should be true
+    expect(voter.voted_as_when_voted_on(votable)).to be true
+    expect(voter.voted_as_when_voted_for(votable)).to be true
   end
 
   it "should be voted as true when a voter has voted true under scope" do
     votable.vote_by :voter => voter, :vote_scope => 'rank'
-    voter.voted_as_when_voted_for(votable, :vote_scope => 'rank').should be true
+    expect(voter.voted_as_when_voted_for(votable, :vote_scope => 'rank')).to be true
   end
 
   it "should be voted as false when a voter has voted false" do
     votable.vote_by :voter => voter, :vote => false
-    voter.voted_as_when_voted_for(votable).should be false
+    expect(voter.voted_as_when_voted_for(votable)).to be false
   end
 
   it "should be voted as false when a voter has voted false under scope" do
     votable.vote_by :voter => voter, :vote => false, :vote_scope => 'rank'
-    voter.voted_as_when_voted_for(votable, :vote_scope => 'rank').should be false
+    expect(voter.voted_as_when_voted_for(votable, :vote_scope => 'rank')).to be false
   end
 
   it "should be voted as nil when a voter has never voted" do
-    voter.voted_as_when_voting_on(votable).should be nil
+    expect(voter.voted_as_when_voting_on(votable)).to be nil
   end
 
   it "should be voted as nil when a voter has never voted under the scope" do
     votable.vote_by :voter => voter, :vote => false, :vote_scope => 'rank'
-    voter.voted_as_when_voting_on(votable).should be nil
+    expect(voter.voted_as_when_voting_on(votable)).to be nil
   end
 
   it "should return true if voter has voted true" do
     votable.vote_by :voter => voter
-    voter.voted_up_on?(votable).should be true
+    expect(voter.voted_up_on?(votable)).to be true
   end
 
   it "should return false if voter has not voted true" do
     votable.vote_by :voter => voter, :vote => false
-    voter.voted_up_on?(votable).should be false
+    expect(voter.voted_up_on?(votable)).to be false
   end
 
   it "should return true if the voter has voted false" do
     votable.vote_by :voter => voter, :vote => false
-    voter.voted_down_on?(votable).should be true
+    expect(voter.voted_down_on?(votable)).to be true
   end
 
   it "should return false if the voter has not voted false" do
     votable.vote_by :voter => voter, :vote => true
-    voter.voted_down_on?(votable).should be false
+    expect(voter.voted_down_on?(votable)).to be false
   end
 
   it "should provide reserve functionality, voter can vote on votable" do
     voter.vote :votable => votable, :vote => 'bad'
-    voter.voted_as_when_voting_on(votable).should be false
+    expect(voter.voted_as_when_voting_on(votable)).to be false
   end
 
   it "should allow the voter to vote up a model" do
     voter.vote_up_for votable
-    votable.get_up_votes.first.voter.should == voter
-    votable.votes_for.up.first.voter.should == voter
+    expect(votable.get_up_votes.first.voter).to eq(voter)
+    expect(votable.votes_for.up.first.voter).to eq(voter)
   end
 
   it "should allow the voter to vote down a model" do
     voter.vote_down_for votable
-    votable.get_down_votes.first.voter.should == voter
-    votable.votes_for.down.first.voter.should == voter
+    expect(votable.get_down_votes.first.voter).to eq(voter)
+    expect(votable.votes_for.down.first.voter).to eq(voter)
   end
 
   it "should allow the voter to unvote a model" do
     voter.vote_up_for votable
     voter.unvote_for votable
-    votable.find_votes_for.size.should == 0
-    votable.votes_for.count.should == 0
+    expect(votable.find_votes_for.size).to eq(0)
+    expect(votable.votes_for.count).to eq(0)
   end
 
   it "should get all of the voters votes" do
     voter.vote_up_for votable
-    voter.find_votes.size.should == 1
-    voter.votes.up.count.should == 1
+    expect(voter.find_votes.size).to eq(1)
+    expect(voter.votes.up.count).to eq(1)
   end
 
   it "should get all of the voters up votes" do
     voter.vote_up_for votable
-    voter.find_up_votes.size.should == 1
-    voter.votes.up.count.should == 1
+    expect(voter.find_up_votes.size).to eq(1)
+    expect(voter.votes.up.count).to eq(1)
   end
 
   it "should get all of the voters down votes" do
     voter.vote_down_for votable
-    voter.find_down_votes.size.should == 1
-    voter.votes.down.count.should == 1
+    expect(voter.find_down_votes.size).to eq(1)
+    expect(voter.votes.down.count).to eq(1)
   end
 
   it "should get all of the votes votes for a class" do
     votable.vote_by :voter => voter
     votable2.vote_by :voter => voter, :vote => false
-    voter.find_votes_for_class(votable_klass).size.should == 2
-    voter.votes.for_type(votable_klass).count.should == 2
+    expect(voter.find_votes_for_class(votable_klass).size).to eq(2)
+    expect(voter.votes.for_type(votable_klass).count).to eq(2)
   end
 
   it "should get all of the voters up votes for a class" do
     votable.vote_by :voter => voter
     votable2.vote_by :voter => voter, :vote => false
-    voter.find_up_votes_for_class(votable_klass).size.should == 1
-    voter.votes.up.for_type(votable_klass).count.should == 1
+    expect(voter.find_up_votes_for_class(votable_klass).size).to eq(1)
+    expect(voter.votes.up.for_type(votable_klass).count).to eq(1)
   end
 
   it "should get all of the voters down votes for a class" do
     votable.vote_by :voter => voter
     votable2.vote_by :voter => voter, :vote => false
-    voter.find_down_votes_for_class(votable_klass).size.should == 1
-    voter.votes.down.for_type(votable_klass).count.should == 1
+    expect(voter.find_down_votes_for_class(votable_klass).size).to eq(1)
+    expect(voter.votes.down.for_type(votable_klass).count).to eq(1)
   end
 
   it "should be contained to instances" do
     voter.vote :votable => votable, :vote => false
     voter2.vote :votable => votable
 
-    voter.voted_as_when_voting_on(votable).should be false
+    expect(voter.voted_as_when_voting_on(votable)).to be false
   end
 
   describe '#find_voted_items' do
     it 'returns objects that a user has upvoted for' do
       votable.vote_by :voter => voter
       votable2.vote_by :voter => voter2
-      voter.find_voted_items.should include votable
-      voter.find_voted_items.size.should == 1
+      expect(voter.find_voted_items).to include votable
+      expect(voter.find_voted_items.size).to eq(1)
     end
 
     it 'returns objects that a user has upvoted for, using scope' do
       votable.vote_by :voter => voter, :vote_scope => 'rank'
       votable2.vote_by :voter => voter2, :vote_scope => 'rank'
-      voter.find_voted_items(:vote_scope => 'rank').should include votable
-      voter.find_voted_items(:vote_scope => 'rank').size.should == 1
+      expect(voter.find_voted_items(:vote_scope => 'rank')).to include votable
+      expect(voter.find_voted_items(:vote_scope => 'rank').size).to eq(1)
     end
 
     it 'returns objects that a user has downvoted for' do
       votable.vote_down voter
       votable2.vote_down voter2
-      voter.find_voted_items.should include votable
-      voter.find_voted_items.size.should == 1
+      expect(voter.find_voted_items).to include votable
+      expect(voter.find_voted_items.size).to eq(1)
     end
 
     it 'returns objects that a user has downvoted for, using scope' do
       votable.vote_down voter, :vote_scope => 'rank'
       votable2.vote_down voter2, :vote_scope => 'rank'
-      voter.find_voted_items(:vote_scope => 'rank').should include votable
-      voter.find_voted_items(:vote_scope => 'rank').size.should == 1
+      expect(voter.find_voted_items(:vote_scope => 'rank')).to include votable
+      expect(voter.find_voted_items(:vote_scope => 'rank').size).to eq(1)
     end
   end
 
@@ -175,55 +175,55 @@ shared_examples "a voter_model" do
     it 'returns objects that a user has upvoted for' do
       votable.vote_by :voter => voter
       votable2.vote_by :voter => voter2
-      voter.find_up_voted_items.should include votable
-      voter.find_up_voted_items.size.should == 1
-      voter.find_liked_items.should include votable
-      voter.find_liked_items.size.should == 1
+      expect(voter.find_up_voted_items).to include votable
+      expect(voter.find_up_voted_items.size).to eq(1)
+      expect(voter.find_liked_items).to include votable
+      expect(voter.find_liked_items.size).to eq(1)
     end
 
     it 'returns objects that a user has upvoted for, using scope' do
       votable.vote_by :voter => voter, :vote_scope => 'rank'
       votable2.vote_by :voter => voter2, :vote_scope => 'rank'
-      voter.find_up_voted_items(:vote_scope => 'rank').should include votable
-      voter.find_up_voted_items(:vote_scope => 'rank').size.should == 1
+      expect(voter.find_up_voted_items(:vote_scope => 'rank')).to include votable
+      expect(voter.find_up_voted_items(:vote_scope => 'rank').size).to eq(1)
     end
 
     it 'does not return objects that a user has downvoted for' do
       votable.vote_down voter
-      voter.find_up_voted_items.size.should == 0
+      expect(voter.find_up_voted_items.size).to eq(0)
     end
 
     it 'does not return objects that a user has downvoted for, using scope' do
       votable.vote_down voter, :vote_scope => 'rank'
-      voter.find_up_voted_items(:vote_scope => 'rank').size.should == 0
+      expect(voter.find_up_voted_items(:vote_scope => 'rank').size).to eq(0)
     end
   end
 
   describe '#find_down_voted_items' do
     it 'does not return objects that a user has upvoted for' do
       votable.vote_by :voter => voter
-      voter.find_down_voted_items.size.should == 0
+      expect(voter.find_down_voted_items.size).to eq(0)
     end
 
     it 'does not return objects that a user has upvoted for, using scope' do
       votable.vote_by :voter => voter, :vote_scope => 'rank'
-      voter.find_down_voted_items(:vote_scope => 'rank').size.should == 0
+      expect(voter.find_down_voted_items(:vote_scope => 'rank').size).to eq(0)
     end
 
     it 'returns objects that a user has downvoted for' do
       votable.vote_down voter
       votable2.vote_down voter2
-      voter.find_down_voted_items.should include votable
-      voter.find_down_voted_items.size.should == 1
-      voter.find_disliked_items.should include votable
-      voter.find_disliked_items.size.should == 1
+      expect(voter.find_down_voted_items).to include votable
+      expect(voter.find_down_voted_items.size).to eq(1)
+      expect(voter.find_disliked_items).to include votable
+      expect(voter.find_disliked_items.size).to eq(1)
     end
 
     it 'returns objects that a user has downvoted for, using scope' do
       votable.vote_down voter, :vote_scope => 'rank'
       votable2.vote_down voter2, :vote_scope => 'rank'
-      voter.find_down_voted_items(:vote_scope => 'rank').should include votable
-      voter.find_down_voted_items(:vote_scope => 'rank').size.should == 1
+      expect(voter.find_down_voted_items(:vote_scope => 'rank')).to include votable
+      expect(voter.find_down_voted_items(:vote_scope => 'rank').size).to eq(1)
     end
 
  end
@@ -234,15 +234,15 @@ shared_examples "a voter_model" do
     it 'returns objects of a class that a voter has voted for' do
       votable.vote_by :voter => voter
       votable2.vote_down voter
-      subject.should include votable
-      subject.should include votable2
-      subject.size.should == 2
+      expect(subject).to include votable
+      expect(subject).to include votable2
+      expect(subject.size).to eq(2)
     end
 
     it 'does not return objects of a class that a voter has voted for' do
       votable.vote_by :voter => voter2
       votable2.vote_by :voter => voter2
-      subject.size.should == 0
+      expect(subject.size).to eq(0)
     end
   end
 
@@ -251,13 +251,13 @@ shared_examples "a voter_model" do
 
     it 'returns up voted items that a voter has voted for' do
       votable.vote_by :voter => voter
-      subject.should include votable
-      subject.size.should == 1
+      expect(subject).to include votable
+      expect(subject.size).to eq(1)
     end
 
     it 'does not return down voted items a voter has voted for' do
       votable.vote_down voter
-      subject.size.should == 0
+      expect(subject.size).to eq(0)
     end
   end
 
@@ -266,13 +266,13 @@ shared_examples "a voter_model" do
 
     it 'does not return up voted items that a voter has voted for' do
       votable.vote_by :voter => voter
-      subject.size.should == 0
+      expect(subject.size).to eq(0)
     end
 
     it 'returns down voted items a voter has voted for' do
       votable.vote_down voter
-      subject.should include votable
-      subject.size.should == 1
+      expect(subject).to include votable
+      expect(subject.size).to eq(1)
     end
   end
 

--- a/spec/votable_spec.rb
+++ b/spec/votable_spec.rb
@@ -3,11 +3,11 @@ require 'spec_helper'
 
 describe ActsAsVotable::Votable do
   it "should not be votable" do
-    NotVotable.should_not be_votable
+    expect(NotVotable).not_to be_votable
   end
 
   it "should be votable" do
-    Votable.should be_votable
+    expect(Votable).to be_votable
   end
 
   it_behaves_like "a votable_model" do

--- a/spec/voter_spec.rb
+++ b/spec/voter_spec.rb
@@ -4,11 +4,11 @@ require 'spec_helper'
 describe ActsAsVotable::Voter do
 
   it "should not be a voter" do
-    NotVotable.should_not be_votable
+    expect(NotVotable).not_to be_votable
   end
 
   it "should be a voter" do
-    Votable.should be_votable
+    expect(Votable).to be_votable
   end
 
   it_behaves_like "a voter_model" do

--- a/spec/words_spec.rb
+++ b/spec/words_spec.rb
@@ -8,23 +8,23 @@ describe ActsAsVotable::Helpers::Words do
   end
 
   it "should know that like is a true vote" do
-    @vote.votable_words.that_mean_true.should include "like"
+    expect(@vote.votable_words.that_mean_true).to include "like"
   end
 
   it "should know that bad is a false vote" do
-    @vote.votable_words.that_mean_false.should include "bad"
+    expect(@vote.votable_words.that_mean_false).to include "bad"
   end
 
   it "should be a vote for true when word is good" do
-    @vote.votable_words.meaning_of('good').should be true
+    expect(@vote.votable_words.meaning_of('good')).to be true
   end
 
   it "should be a vote for false when word is down" do
-    @vote.votable_words.meaning_of('down').should be false
+    expect(@vote.votable_words.meaning_of('down')).to be false
   end
 
   it "should be a vote for true when the word is unknown" do
-    @vote.votable_words.meaning_of('lsdhklkadhfs').should be true
+    expect(@vote.votable_words.meaning_of('lsdhklkadhfs')).to be true
   end
 
 end


### PR DESCRIPTION
This conversion is done by Transpec 2.2.4 with the following command:
    transpec
- 154 conversions
  from: obj.should
    to: expect(obj).to
- 104 conversions
  from: == expected
    to: eq(expected)
- 3 conversions
  from: obj.should_not
    to: expect(obj).not_to

For more details: https://github.com/yujinakayama/transpec#supported-conversions
