### PR TITLE
Fix rails4 issue when using protected_attributes gem

### DIFF
--- a/lib/acts_as_votable/vote.rb
+++ b/lib/acts_as_votable/vote.rb
@@ -5,7 +5,7 @@ module ActsAsVotable
 
     include Helpers::Words
 
-    if ::ActiveRecord::VERSION::MAJOR < 4
+    if defined?(ProtectedAttributes) || ::ActiveRecord::VERSION::MAJOR < 4
       attr_accessible :votable_id, :votable_type,
         :voter_id, :voter_type,
         :votable, :voter,


### PR DESCRIPTION
Adressing issue #56, checking for protected_attributes or !strongparameters, instead of rails version.
