### PR TITLE
Bump sqlite3 gem and use pessimistic version constraint

### DIFF
--- a/acts_as_votable.gemspec
+++ b/acts_as_votable.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_development_dependency "rspec"
-  s.add_development_dependency "sqlite3", '1.3.7'
+  s.add_development_dependency "sqlite3", '~> 1.3.9'
 end


### PR DESCRIPTION
Minor commit - bumps the sqlite3 gem from 1.3.7 to 1.3.9 and now uses pessimistic version constraint.

Really helpful gem, thanks!
