### PR TITLE
Fix strange behavior of caching total votes on scoped voting

### DIFF
--- a/lib/acts_as_votable/votable.rb
+++ b/lib/acts_as_votable/votable.rb
@@ -11,7 +11,7 @@ module ActsAsVotable
       aliases = {
 
         :vote_up => [
-          :up_by, :upvote_by, :like_by, :liked_by, 
+          :up_by, :upvote_by, :like_by, :liked_by,
           :up_from, :upvote_from, :upvote_by, :like_from, :liked_from, :vote_from
         ],
 
@@ -254,11 +254,13 @@ module ActsAsVotable
     end
 
     def get_up_votes options={}
-      find_votes_for(:vote_flag => true, :vote_scope => options[:vote_scope])
+      vote_scope_hash = scope_or_empty_hash(options[:vote_scope])
+      find_votes_for({:vote_flag => true}.merge(vote_scope_hash))
     end
 
     def get_down_votes options={}
-      find_votes_for(:vote_flag => false, :vote_scope => options[:vote_scope])
+      vote_scope_hash = scope_or_empty_hash(options[:vote_scope])
+      find_votes_for({:vote_flag => false}.merge(vote_scope_hash))
     end
 
 
@@ -267,7 +269,7 @@ module ActsAsVotable
       if !skip_cache && self.respond_to?(scope_cache_field :cached_votes_total, vote_scope)
         return self.send(scope_cache_field :cached_votes_total, vote_scope)
       end
-      find_votes_for(:vote_scope => vote_scope).count
+      find_votes_for(scope_or_empty_hash(vote_scope)).count
     end
 
     def count_votes_up skip_cache = false, vote_scope = nil
@@ -321,5 +323,10 @@ module ActsAsVotable
       votes.count > 0
     end
 
+    private
+
+    def scope_or_empty_hash(vote_scope)
+      vote_scope ? { :vote_scope => vote_scope } : {}
+    end
   end
 end

--- a/spec/shared_example/votable_model_spec.rb
+++ b/spec/shared_example/votable_model_spec.rb
@@ -337,10 +337,43 @@ shared_examples "a votable_model" do
       expect(votable_cache.weighted_average).to eq(50)
     end
 
+    it "should update cached total votes_for when voting under an scope" do
+      votable_cache.vote_by :voter => voter, :vote => 'true', :vote_scope => 'rank'
+      expect(votable_cache.cached_votes_total).to eq(1)
+    end
+
+    it "should update cached up votes_for when voting under an scope" do
+      votable_cache.vote_by :voter => voter, :vote => 'true', :vote_scope => 'rank'
+      expect(votable_cache.cached_votes_up).to eq(1)
+    end
+
+    it "should update cached total votes_for when a scoped vote down is removed" do
+      votable_cache.vote_by :voter => voter, :vote => 'true', :vote_scope => 'rank'
+      votable_cache.unvote :voter => voter, :vote_scope => 'rank'
+      expect(votable_cache.cached_votes_total).to eq(0)
+    end
+
+    it "should update cached up votes_for when a scoped vote down is removed" do
+      votable_cache.vote_by :voter => voter, :vote => 'true', :vote_scope => 'rank'
+      votable_cache.unvote :voter => voter, :vote_scope => 'rank'
+      expect(votable_cache.cached_votes_up).to eq(0)
+    end
+
+    it "should update cached down votes_for when downvoting under a scope" do
+      votable_cache.vote_by :voter => voter, :vote => 'false', :vote_scope => 'rank'
+      expect(votable_cache.cached_votes_down).to eq(1)
+    end
+
+    it "should update cached down votes_for when a scoped vote down is removed" do
+      votable_cache.vote_by :voter => voter, :vote => 'false', :vote_scope => 'rank'
+      votable_cache.unvote :voter => voter, :vote_scope => 'rank'
+      expect(votable_cache.cached_votes_down).to eq(0)
+    end
+
   end
 
   describe "with scoped cached votes_for" do
-    
+
     it "should update cached total votes_for if there is a total column" do
       votable_cache.cached_scoped_test_votes_total = 50
       votable_cache.vote_by :voter => voter, :vote_scope => "test"


### PR DESCRIPTION
This pull-request for #100 fixes behavior of caching votes when voting with scope param.
