### PR TITLE
Added instructions on how to remove a scoped vote

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -166,11 +166,9 @@ You can add a scope to your vote
 @post.find_votes_for(:vote_scope => 'month').size # => 1
 
 # To remove a vote with a scope, simply do:
-
-# Short Hand Version
 @post.unvote_by @user1, vote_scope: 'week'
 
-# Long Hand Version
+# Note that the following will NOT work:
 @post.unvote_by voter: @user2, vote_scope: 'month'
 ```
 ### Adding weights to your votes

--- a/README.markdown
+++ b/README.markdown
@@ -164,6 +164,14 @@ You can add a scope to your vote
 @post.votes_for.size # => 2
 @post.find_votes_for(:vote_scope => 'week').size # => 1
 @post.find_votes_for(:vote_scope => 'month').size # => 1
+
+# To remove a vote with a scope, simply do:
+
+# Short Hand Version
+@post.unvote_by @user1, vote_scope: 'week'
+
+# Long Hand Version
+@post.unvote_by voter: @user2, vote_scope: 'month'
 ```
 ### Adding weights to your votes
 


### PR DESCRIPTION
The documentation was a bit light on how to `unvote` a vote that had been applied with a scope. Just doing a regular `unvote` doesn't work. 

The test suite should also be updated to reflect this.
