### PR TITLE
hotfix: remove blank key form extra_conditions params in method find_…

### DIFF
--- a/lib/acts_as_votable/votable.rb
+++ b/lib/acts_as_votable/votable.rb
@@ -250,7 +250,7 @@ module ActsAsVotable
 
     # results
     def find_votes_for extra_conditions = {}
-      votes_for.where(extra_conditions)
+      votes_for.where(extra_conditions.compact)
     end
 
     def get_up_votes options={}


### PR DESCRIPTION
hello, when i user the gem , i find some question, finally, i have resolved it,  remove blank key form extra_conditions params in method find_votes_for
