### PR TITLE
Explicitly declare the license type in the gemspec

### DIFF
--- a/acts_as_votable.gemspec
+++ b/acts_as_votable.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |s|
   s.homepage    = "http://rubygems.org/gems/acts_as_votable"
   s.summary     = %q{Rails gem to allowing records to be votable}
   s.description = %q{Rails gem to allowing records to be votable}
+  s.license     = "MIT"
 
   s.rubyforge_project = "acts_as_votable"
 


### PR DESCRIPTION
The gemspec does not explicitly declare the license type. `license` is a recommended attribute in the gemspec: http://guides.rubygems.org/specification-reference/#license=

This PR sets the license attribute to MIT because that is the license used by this repository.

This will assist in using this gem with other software that tracks software licenses, for example, the [papers](https://github.com/newrelic/papers) gem. It will require a release to rubygems.org.