### PR TITLE
Vote cache transaction

### DIFF
--- a/acts_as_votable.gemspec
+++ b/acts_as_votable.gemspec
@@ -28,4 +28,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "simplecov", "~> 0.15.0"
   s.add_development_dependency "appraisal", "~> 2.2"
   s.add_development_dependency "factory_girl", "~> 4.8"
+  s.add_development_dependency "activerecord", "~> 5.1"
+  s.add_development_dependency "railties", "~> 5.1"
 end

--- a/lib/acts_as_votable/votable.rb
+++ b/lib/acts_as_votable/votable.rb
@@ -100,13 +100,15 @@ module ActsAsVotable
       #Allowing for a vote_weight to be associated with every vote. Could change with every voter object
       vote.vote_weight = (options[:vote_weight].to_i if options[:vote_weight].present?) || 1
 
-      if vote.save
-        self.vote_registered = true if last_update != vote.updated_at
-        update_cached_votes options[:vote_scope]
-        return true
-      else
-        self.vote_registered = false
-        return false
+      vote.transaction do
+        if vote.save
+          self.vote_registered = true if last_update != vote.updated_at
+          update_cached_votes options[:vote_scope]
+          return true
+        else
+          self.vote_registered = false
+          return false
+        end
       end
     end
 
@@ -115,8 +117,10 @@ module ActsAsVotable
       votes = find_votes_for(voter_id: args[:voter].id, vote_scope: args[:vote_scope], voter_type: args[:voter].class.base_class.name)
 
       return true if votes.size == 0
-      votes.each(&:destroy)
-      update_cached_votes args[:vote_scope]
+      votes.first.transaction do
+        votes.each(&:destroy)
+        update_cached_votes args[:vote_scope]
+      end
       self.vote_registered = false if votes_for.count == 0
       return true
     end

--- a/spec/shared_example/votable_model.rb
+++ b/spec/shared_example/votable_model.rb
@@ -163,6 +163,32 @@ shared_examples "a votable_model" do
       expect(votable_cache.cached_votes_total).to eq(1)
     end
 
+    describe "with ActiveRecord::StaleObjectError" do
+      it "should rollback vote up if cache update fails" do
+        votable_cache.cached_votes_total = 50
+        allow_any_instance_of(ActsAsVotable::Cacheable)
+          .to(receive(:update_cached_votes)
+          .and_raise(ActiveRecord::StaleObjectError))
+
+        expect { votable_cache.vote_by voter: voter }.to raise_error ActiveRecord::StaleObjectError
+        expect(votable_cache.cached_votes_total).to eq(50)
+        expect(votable_cache.voted_on_by?(voter)).to be false
+      end
+
+      it "should rollback unvote if cache update fails" do
+        votable_cache.vote_by voter: voter, vote: "true"
+
+        allow_any_instance_of(ActsAsVotable::Cacheable)
+          .to(receive(:update_cached_votes)
+          .and_raise(ActiveRecord::StaleObjectError))
+
+        expect { votable_cache.unvote voter: voter }.to raise_error ActiveRecord::StaleObjectError
+
+        expect(votable_cache.cached_votes_total).to eq(1)
+        expect(votable_cache.voted_on_by?(voter)).to be true
+      end
+    end
+
     it "should update cached total votes_for when a vote up is removed" do
       votable_cache.vote_by voter: voter, vote: "true"
       votable_cache.unvote voter: voter


### PR DESCRIPTION
My second attempt at fixing issue 162 that I opened a few days ago. This time with no breaking changes requiring votable.reload to see updated counts after vote_by. 

If for whatever reason this can't be merged I'd appreciate some guidance on what to improve, it's my first pull request. 