### PR TITLE
Optimize db queries in several places

### DIFF
--- a/lib/acts_as_votable/voter.rb
+++ b/lib/acts_as_votable/voter.rb
@@ -18,7 +18,7 @@ module ActsAsVotable
 
       base.class_eval do
 
-        has_many :votes, class_name: "ActsAsVotable::Vote", as: :voter, dependent: :destroy do
+        has_many :votes, class_name: "ActsAsVotable::Vote", as: :voter, dependent: :delete_all do
           def votables
             includes(:votable).map(&:votable)
           end


### PR DESCRIPTION
This PR reduces and avoids db queries at several places.
Primarily this is  done by replacing `COUNT..` by `SELECT 1...`, using already calculated values and replacing many queries by one (like `.destroy` vs `delete`).