### PR TITLE
Remove ruby 2.2 travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: ruby
 cache: bundler
 
 rvm:
-  - 2.2.7
   - 2.3.4
   - 2.4.2
   - 2.5.1

--- a/README.markdown
+++ b/README.markdown
@@ -16,9 +16,8 @@ The main goals of this gem are:
 
 ### Supported Ruby and Rails versions
 
-* Ruby 2.2.0, 2.3.0 and 2.4.0
-* Rails 4.0, 4.1+
-* Rails 5.0, 5.1
+* Ruby >= 2.3.0
+* Rails >= 4
 
 ### Install
 


### PR DESCRIPTION
Ruby 2.2 end of life has been reached. Stop supporting it.