### PR TITLE
use rails autoloading and avoid deep require calls

### DIFF
--- a/lib/acts_as_votable.rb
+++ b/lib/acts_as_votable.rb
@@ -2,20 +2,26 @@
 
 require "active_record"
 require "active_support/inflector"
+require "active_support/dependencies/autoload"
 
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 
 module ActsAsVotable
+  extend ActiveSupport::Autoload
+
+  autoload :Votable
+  autoload :Vote
+  autoload :Voter
+  autoload :Cacheable
+  autoload :Extenders
+  autoload :Helpers
+
   if defined?(ActiveRecord::Base)
-    require "acts_as_votable/extenders/votable"
-    require "acts_as_votable/extenders/voter"
-    require "acts_as_votable/vote"
     ActiveRecord::Base.extend ActsAsVotable::Extenders::Votable
     ActiveRecord::Base.extend ActsAsVotable::Extenders::Voter
   end
 end
 
-require "acts_as_votable/extenders/controller"
 ActiveSupport.on_load(:action_controller) do
   include ActsAsVotable::Extenders::Controller
 end

--- a/lib/acts_as_votable/extenders.rb
+++ b/lib/acts_as_votable/extenders.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module ActsAsVotable
+  module Extenders
+    extend ActiveSupport::Autoload
+
+    autoload :"Votable"
+    autoload :"Voter"
+    autoload :"Controller"
+  end
+end

--- a/lib/acts_as_votable/extenders/votable.rb
+++ b/lib/acts_as_votable/extenders/votable.rb
@@ -10,7 +10,6 @@ module ActsAsVotable
       end
 
       def acts_as_votable(args = {})
-        require "acts_as_votable/votable"
         include ActsAsVotable::Votable
 
         if args.key?(:cacheable_strategy) && !ALLOWED_CACHEABLE_STRATEGIES.include?(args[:cacheable_strategy])

--- a/lib/acts_as_votable/extenders/voter.rb
+++ b/lib/acts_as_votable/extenders/voter.rb
@@ -8,7 +8,6 @@ module ActsAsVotable
       end
 
       def acts_as_voter(*_args)
-        require "acts_as_votable/voter"
         include ActsAsVotable::Voter
 
         class_eval do

--- a/lib/acts_as_votable/helpers.rb
+++ b/lib/acts_as_votable/helpers.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module ActsAsVotable
+  module Helpers
+    extend ActiveSupport::Autoload
+
+    autoload :"Words"
+  end
+end

--- a/lib/acts_as_votable/votable.rb
+++ b/lib/acts_as_votable/votable.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "acts_as_votable/helpers/words"
-require "acts_as_votable/cacheable"
 
 module ActsAsVotable
   module Votable


### PR DESCRIPTION
This PR is a small refactoring that makes AAV use Rails' autoloading mechanisms to avoid using nested `require` calls.

This fixes an issue in **development** where in some situations I encountered `unitialized constant ActsAsVotable::Votable` errors due to calling `ActsAsVotable::Votable` directly in a place where Rails' hadn't already loaded a votable model, thus requiring the `acts_as_votable/votable` file.

Since the gem already depends on ActiveSupport, its autoload feature seems a good fit to allow the lazy loading provided by the original `require` calls without its drawbacks.

Note : I converted all local `require` calls to `autoload`, and created the needed parent module files (`acts_as_votable/extenders.rb` and `acts_as_votable/helpers.rb`. This is not mandatory but this way there's only one method used throughout the gem.