### PR TITLE
README: Update example API calls for votes, likes, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,9 +199,9 @@ end
 
 @user.likes @article
 
-@article.votes.size # => 1
-@article.likes.size # => 1
-@article.dislikes.size # => 0
+@article.votes_for.size # => 1
+@article.get_likes.size # => 1
+@article.get_dislikes.size # => 0
 ```
 
 To check if a voter has voted on a model, you can use ``voted_for?``.  You can
@@ -274,8 +274,8 @@ because `@user` has already voted for `@shoe`.
 @user.likes @shoe
 @user.likes @shoe
 
-@shoe.votes # => 1
-@shoe.likes # => 1
+@shoe.votes_for.size # => 1
+@shoe.get_likes.size # => 1
 ```
 
 To check if a vote counted, or registered, use `vote_registered?` on your model
@@ -291,9 +291,9 @@ after voting.  For example:
 @hat.disliked_by @user
 @hat.vote_registered? # => true, because user changed their vote
 
-@hat.votes.size # => 1
-@hat.positives.size # => 0
-@hat.negatives.size # => 1
+@hat.votes_for.size # => 1
+@hat.get_positives.size # => 0
+@hat.get_negatives.size # => 1
 ```
 
 To permit duplicates entries of a same voter, use option duplicate. Also notice that this


### PR DESCRIPTION
The API has changed for retrieving votes, likes, dislikes, positives, negatives, etc, particularly in 0.8.0.

Update the API examples from #votes to #votes_for and the like.

(Thanks for all things `acts_as_votable` !)
