### PR TITLE
Pin sqlite version to fix failing travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,13 @@ rvm:
 
 before_install:
   - gem update --system
+  # Stay on Bundler 1.x (for dependency reasons as we want to support Rails 4.2.x and Ruby 2.3.x)
+  # More info here: https://docs.travis-ci.com/user/languages/ruby/#bundler-20
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler -v '< 2'
 
 gemfile:
   - gemfiles/rails_4.gemfile
   - gemfiles/rails_5.gemfile
   - gemfiles/rails_5_1.gemfile
   - gemfiles/rails_5_2.gemfile
-

--- a/acts_as_votable.gemspec
+++ b/acts_as_votable.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_development_dependency "rspec", "~> 3.6"
-  s.add_development_dependency "sqlite3", "~> 1.3"
+  s.add_development_dependency "sqlite3", "~> 1.3.6"
   s.add_development_dependency "rubocop", "~> 0.49.1"
   s.add_development_dependency "simplecov", "~> 0.15.0"
   s.add_development_dependency "appraisal", "~> 2.2"


### PR DESCRIPTION
See here for more info: rails/rails#35153 and rails/rails#35154

Fixes this current issue on Travis CI for the other recent PRs:

```
Failure/Error: ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
Gem::LoadError:
  Error loading the 'sqlite3' Active Record adapter. Missing a gem it depends on? can't activate sqlite3 (~> 1.3.6), already activated sqlite3-1.4.1. Make sure all dependencies are added to Gemfile.
```