### PR TITLE
'update_attributes' deprecated in Rails 6 (and removes in Rails 6.1)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,13 @@ rvm:
 
 before_install:
   - gem update --system
+  # Stay on Bundler 1.x (for dependency reasons as we want to support Rails 4.2.x and Ruby 2.3.x)
+  # More info here: https://docs.travis-ci.com/user/languages/ruby/#bundler-20
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler -v '< 2'
 
 gemfile:
   - gemfiles/rails_4.gemfile
   - gemfiles/rails_5.gemfile
   - gemfiles/rails_5_1.gemfile
   - gemfiles/rails_5_2.gemfile
-

--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ Display average rating:
 You can control whether `updated_at` column of votable model will be touched or
 not by passing `cacheable_strategy` option to `acts_as_votable` method.
 
-By default, `update_attributes` strategy is used. Pass `:update_columns` as
+By default, `update` strategy is used. Pass `:update_columns` as
 `cacheable_strategy` if you don't want to touch model's `updated_at` column.
 ```ruby
 class Post < ActiveRecord::Base

--- a/acts_as_votable.gemspec
+++ b/acts_as_votable.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_development_dependency "rspec", "~> 3.6"
-  s.add_development_dependency "sqlite3", "~> 1.3"
+  s.add_development_dependency "sqlite3", "~> 1.3.6"
   s.add_development_dependency "rubocop", "~> 0.49.1"
   s.add_development_dependency "simplecov", "~> 0.15.0"
   s.add_development_dependency "appraisal", "~> 2.2"

--- a/lib/acts_as_votable/extenders/votable.rb
+++ b/lib/acts_as_votable/extenders/votable.rb
@@ -3,7 +3,7 @@
 module ActsAsVotable
   module Extenders
     module Votable
-      ALLOWED_CACHEABLE_STRATEGIES = %i[update_attributes update_columns]
+      ALLOWED_CACHEABLE_STRATEGIES = %i[update update_columns]
 
       def votable?
         false
@@ -23,7 +23,7 @@ module ActsAsVotable
 
         class_eval do
           @acts_as_votable_options = {
-            cacheable_strategy: :update_attributes
+            cacheable_strategy: :update
           }.merge(args)
 
           def self.votable?

--- a/spec/factories/votable_cache_update_attributes.rb
+++ b/spec/factories/votable_cache_update_attributes.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :votable_cache_update_attributes do
+  factory :votable_cache_update do
   end
 end

--- a/spec/shared_example/votable_model.rb
+++ b/spec/shared_example/votable_model.rb
@@ -411,8 +411,8 @@ shared_examples "a votable_model" do
 
         before { votable_cache.vote_by voter: voter }
 
-        context "update_attributes" do
-          let(:votable_cache) { create(:votable_cache_update_attributes, name: "voting model with cache", updated_at: updated_at) }
+        context "update" do
+          let(:votable_cache) { create(:votable_cache_update, name: "voting model with cache", updated_at: updated_at) }
 
           it do
             expect(votable_cache.cached_votes_total).to eq(1)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -124,8 +124,8 @@ class VotableCache < ActiveRecord::Base
   validates_presence_of :name
 end
 
-class VotableCacheUpdateAttributes < VotableCache
-  acts_as_votable cacheable_strategy: :update_attributes
+class VotableCacheUpdate < VotableCache
+  acts_as_votable cacheable_strategy: :update
 end
 
 class VotableCacheUpdateColumns < VotableCache


### PR DESCRIPTION
PR fixes the following warning: 

```
DEPRECATION WARNING: update_attributes is deprecated and will be removed from Rails 6.1 (please, use update instead)
```

`update_attributes` is just an alias for `update`. `update_attributes` was deprecated in Rails 6.
More info here: https://github.com/rails/rails/pull/31998


Note: This is build off my previous PR here: https://github.com/ryanto/acts_as_votable/pull/198
Please merge this one first. Once merge, the diffs will get cleaned up

Thanks!