### PR TITLE
Don't return from within a transaction

### DIFF
--- a/acts_as_votable.gemspec
+++ b/acts_as_votable.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_development_dependency "rspec", "~> 3.6"
-  s.add_development_dependency "sqlite3", "~> 1.3.6"
+  s.add_development_dependency "sqlite3", "~> 1.4.2"
   s.add_development_dependency "rubocop", "~> 0.49.1"
   s.add_development_dependency "simplecov", "~> 0.15.0"
   s.add_development_dependency "appraisal", "~> 2.2"

--- a/lib/acts_as_votable/votable.rb
+++ b/lib/acts_as_votable/votable.rb
@@ -93,14 +93,16 @@ module ActsAsVotable
       #Allowing for a vote_weight to be associated with every vote. Could change with every voter object
       vote.vote_weight = (options[:vote_weight].to_i if options[:vote_weight].present?) || 1
 
+      vote_saved = false
       ActiveRecord::Base.transaction do
         self.vote_registered = false
-        return false unless vote.save
-
-        self.vote_registered = true if last_update != vote.updated_at
-        update_cached_votes(options[:vote_scope])
-        return true
+        vote_saved = vote.save
+        if vote_saved
+          self.vote_registered = true if last_update != vote.updated_at
+          update_cached_votes(options[:vote_scope])
+        end
       end
+      vote_saved
     end
 
     def unvote(args = {})


### PR DESCRIPTION
This is a PR to address Rails deprecating `return`ing from within an ActiveRecord transaction, this PR resolves #208 .

```
DEPRECATION WARNING: Using `return`, `break` or `throw` to exit a transaction block is
deprecated without replacement. If the `throw` came from
`Timeout.timeout(duration)`, pass an exception class as a second
argument so it doesn't use `throw` to abort its block. This results
in the transaction being committed, but in the next release of Rails
it will rollback.
 (called from vote_by at /bundle/gems/acts_as_votable-0.12.1/lib/acts_as_votable/votable.rb:96)
```