### PR TITLE
Return back the old sqlite3 version

### DIFF
--- a/acts_as_votable.gemspec
+++ b/acts_as_votable.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_development_dependency "rspec", "~> 3.6"
-  s.add_development_dependency "sqlite3", "~> 1.4.2"
+  s.add_development_dependency "sqlite3", "~> 1.3.6"
   s.add_development_dependency "rubocop", "~> 0.49.1"
   s.add_development_dependency "simplecov", "~> 0.15.0"
   s.add_development_dependency "appraisal", "~> 2.2"


### PR DESCRIPTION
This change https://github.com/ryanto/acts_as_votable/commit/a2c2bef1d3b2e69879f5342b66cb7a8e64cc68ee#diff-1881ff6659c18d140c4b8d07623dadba3b0e6be2211b03b39ff2148ddef43e87R24
broke the build and tests.

```
...
An error occurred while loading ./spec/votable_spec.rb. - Did you mean?
                    rspec ./spec/voter_spec.rb

Failure/Error: ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")

Gem::LoadError:
  Error loading the 'sqlite3' Active Record adapter. Missing a gem it depends on? can't activate sqlite3 (~> 1.3.6), already activated sqlite3-1.4.2. Make sure all dependencies are added to Gemfile.
# ./spec/spec_helper.rb:14:in `<top (required)>'
# ./spec/votable_spec.rb:3:in `<top (required)>'
# ------------------
# --- Caused by: ---
# Gem::LoadError:
#   can't activate sqlite3 (~> 1.3.6), already activated sqlite3-1.4.2. Make sure all dependencies are added to Gemfile.
#   ./spec/spec_helper.rb:14:in `<top (required)>'
...
```